### PR TITLE
fix startup error when running on MacOs

### DIFF
--- a/src.main/ElectronMain.hx
+++ b/src.main/ElectronMain.hx
@@ -25,6 +25,7 @@ class ElectronMain {
 			#end
 
 			// Start renderer part
+			mainWindow.show();
 			mainWindow.maximize();
 			mainWindow.loadURL('file://$__dirname/app.html');
 			mainWindow.on('closed', function() {


### PR DESCRIPTION
Fix for #104 bug when trying to run on MacOs due to window not being set to visible first. Simply pasted the fix from there into an actual PR. Have not tested if it breaks anything on windows just yet, but I don't think it should. Please test it out. Forgive me if I did not follow pr post guidelines as this is my first one, I am going to go take a look at them now if they exist and update this to match.