### PR TITLE
Add Action for Ubuntu Build

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,47 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI-ubuntu
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        haxe: [4.1.2]
+      fail-fast: true
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - uses: krdlab/setup-haxe@v1
+        with:
+          haxe-version: 4.1.2
+      - run: |
+          haxe -version
+          haxelib install castle
+          haxelib git heaps https://github.com/HeapsIO/heaps.git
+          haxelib git hxnodejs https://github.com/HaxeFoundation/hxnodejs.git
+          haxelib git electron https://github.com/tong/hxelectron.git
+          haxelib git deepnightLibs https://github.com/deepnight/deepnightLibs.git
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '14'
+      - run: cd app && npm install
+      - run: cd app && npm run compile
+      - run: cd app && npm run pack-linux
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ubuntu-distribution
+          path: app/redist/LEd**installer.AppImage


### PR DESCRIPTION
Addresses #54

Hey I saw that #54 was open and figured I'd take a stab at adding an action for it based off of the discussion from there. This adds a new action to package an Ubuntu build and only exposes the AppImage. I figure for the snap we would want to have an action that actually publishes it to the Snap Store and that's why I didn't add it. See attached the AppImage running on my system. 

![Screenshot from 2020-10-05 11-44-28](https://user-images.githubusercontent.com/15268207/95101786-92401600-0700-11eb-9acc-c80e2b6c87b6.png)
