### PR TITLE
Make the distribution use the DMG file rather than the zip file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,3 +41,7 @@ jobs:
       - run: cd app && npm install
       - run: cd app && npm run compile
       - run: cd app && npm run pack-mac
+      - uses: actions/upload-artifact@v2
+        with:
+          name: mac-distribution
+          path: app/redist/LEd**installer.zip


### PR DESCRIPTION
This PR is for issue #53, see comment https://github.com/deepnight/led/pull/111#issuecomment-707339981

The DMG file should not have any of those issues outlined in the comment.