### PR TITLE
Fix toggling optional rule groups

### DIFF
--- a/src/electron.renderer/ui/modal/panel/EditAllAutoLayerRules.hx
+++ b/src/electron.renderer/ui/modal/panel/EditAllAutoLayerRules.hx
@@ -746,18 +746,6 @@ class EditAllAutoLayerRules extends ui.modal.Panel {
 
 			if( rg.isOptional )
 				ctx.addActionElement({
-					label: L.t._("Turn into an OPTIONAL group"),
-					subText: L.t._("An optional group is disabled everywhere by default, and can be enabled manually only in some specific levels."),
-					iconId: "optional",
-					cb: ()->{
-						invalidateRuleGroup(rg);
-						rg.isOptional = true;
-						rg.active = true; // just some cleanup
-						editor.ge.emit( LayerRuleGroupChanged(rg) );
-					},
-				});
-			else
-				ctx.addActionElement({
 					label: L.t._("Disable OPTIONAL state"),
 					cb: ()->{
 						new ui.modal.dialog.Confirm(
@@ -770,6 +758,18 @@ class EditAllAutoLayerRules extends ui.modal.Panel {
 								editor.ge.emit( LayerRuleGroupChanged(rg) );
 							}
 						);
+					},
+				});
+			else
+				ctx.addActionElement({
+					label: L.t._("Turn into an OPTIONAL group"),
+					subText: L.t._("An optional group is disabled everywhere by default, and can be enabled manually only in some specific levels."),
+					iconId: "optional",
+					cb: ()->{
+						invalidateRuleGroup(rg);
+						rg.isOptional = true;
+						rg.active = true; // just some cleanup
+						editor.ge.emit( LayerRuleGroupChanged(rg) );
 					},
 				});
 		});


### PR DESCRIPTION
fix a regression introduced in deepnight/ldtk@225a891faae5b7d6b5b9a067460a8202e1e17d4b

I simply swapped conditional branches, and built/tested via `npm run pack-linux-x86` and it seems to have fixed the regression

closes #1059

also, apologies if this should be merged into `master`, not completely sure on the repository setup/regular practices.

P.S. Thanks so much for the awesome tool!! :)