### PR TITLE
Allow setting custom IntGrid values

### DIFF
--- a/app/assets/tpl/editLayerDefs.html
+++ b/app/assets/tpl/editLayerDefs.html
@@ -231,7 +231,7 @@
 
 			<xml id="intGridValue">
 				<div class="sortHandle"></div>
-				<span class="id">?</span>
+				<input class="id" type="text" placeholder="0"/>
 				<input type="color" value="#ffffff"/>
 				<span class="tile"></span>
 				<input type="text" class="name" placeholder="Optional value identifier"/>

--- a/src/electron.renderer/data/def/AutoLayerRuleDef.hx
+++ b/src/electron.renderer/data/def/AutoLayerRuleDef.hx
@@ -60,6 +60,19 @@ class AutoLayerRuleDef {
 				explicitlyRequiredValues.push(v);
 	}
 
+	public function updateIntGridValueDef(prev:Int,next:Int) {
+		// Use get/setPattern so that the usage counts, etc. are updated.
+		for(cx in 0...size)
+		for(cy in 0...size) {
+			if(getPattern(cx,cy) == prev)
+				setPattern(cx,cy,next);
+			// Negative values are used to store the logical negation of a tile, so we have to update them too.
+			if(getPattern(cx,cy) == -prev)
+				setPattern(cx,cy,-next);
+		}
+		updateUsedValues();
+	}
+
 	public inline function hasAnyPositionOffset() {
 		return tileRandomXMin!=0 || tileRandomXMax!=0 || tileRandomYMin!=0 || tileRandomYMax!=0 || tileXOffset!=0 || tileYOffset!=0;
 	}

--- a/src/electron.renderer/data/def/LayerDef.hx
+++ b/src/electron.renderer/data/def/LayerDef.hx
@@ -321,6 +321,13 @@ class LayerDef {
 		return false;
 	}
 
+	public function updateIntGridValueDef(prev:Int, next:Int) {
+		var iv = getIntGridValueDef(prev);
+		if(iv == null)
+			return;
+		iv.value = next;
+	}
+
 	public inline function getIntGridValueDef(value:Int) : Null<IntGridValueDefEditor> {
 		var out : Null<IntGridValueDefEditor> = null;
 		for(v in intGridValues)
@@ -448,6 +455,18 @@ class LayerDef {
 	}
 
 	public inline function countIntGridValues() return intGridValues.length;
+
+	public function isIntGridValueValid(value:Int) : Bool {
+		// Negative values are used to logically invert patterns, so zero and negative values are not allowed.
+		// AutoLayerRuleDef::isUsingUnknownIntGridValues requires the value be less than or equal to 999.
+		if ( value <= 0 || value > 999 )
+			return false;
+
+		for(v in intGridValues)
+			if ( v.value == value )
+				return false;
+		return true;
+	}
 
 	public function isIntGridValueIdentifierValid(id:Null<String>) {
 		if( id==null || id=="" )

--- a/src/electron.renderer/data/inst/LayerInstance.hx
+++ b/src/electron.renderer/data/inst/LayerInstance.hx
@@ -686,6 +686,25 @@ class LayerInstance {
 			asyncErase(cx,cy);
 	}
 
+	public function updateIntGridValue(prev:Int, next:Int, useAsyncRender:Bool) {
+		requireType(IntGrid);
+		def.updateIntGridValueDef(prev,next);
+		for(cy in 0...cHei)
+		for(cx in 0...cWid)
+			if ( getIntGrid(cx,cy) == prev )
+				setIntGrid(cx,cy,next,useAsyncRender);
+
+		// We update our own level definition separately because we don't appear in our own autoSourceLayerDefUid.
+		for(rg in def.autoRuleGroups)
+			for(r in rg.rules)
+				r.updateIntGridValueDef(prev, next);
+
+		for(ld in _project.defs.layers)
+			if(ld.autoSourceLayerDefUid == layerDefUid)
+				for(rg in ld.autoRuleGroups)
+					for(r in rg.rules)
+						r.updateIntGridValueDef(prev, next);
+	}
 
 	/** ENTITY INSTANCE *******************/
 

--- a/src/electron.renderer/data/inst/LayerInstance.hx
+++ b/src/electron.renderer/data/inst/LayerInstance.hx
@@ -704,6 +704,8 @@ class LayerInstance {
 				for(rg in ld.autoRuleGroups)
 					for(r in rg.rules)
 						r.updateIntGridValueDef(prev, next);
+
+		level.invalidateJsonCache();
 	}
 
 	/** ENTITY INSTANCE *******************/

--- a/src/electron.renderer/ui/Notification.hx
+++ b/src/electron.renderer/ui/Notification.hx
@@ -92,6 +92,10 @@ class Notification extends dn.Process {
 		}
 	}
 
+	public static function invalidValue(value:Int) {
+		error( Lang.t._("The value \"::value::\" isn't valid, or isn't unique.", { value:value }) );
+	}
+
 	public static function invalidIdentifier(id:String) {
 		error( Lang.t._("The identifier \"::id::\" isn't valid, or isn't unique.", { id:id }) );
 	}

--- a/src/electron.renderer/ui/modal/panel/EditLayerDefs.hx
+++ b/src/electron.renderer/ui/modal/panel/EditLayerDefs.hx
@@ -681,13 +681,26 @@ class EditLayerDefs extends ui.modal.Panel {
 						jValue.attr("valueId", Std.string(intGridVal.value));
 						jValue.addClass("value");
 						jValue.appendTo(jGroup);
-						jValue.find(".id")
-							.html( Std.string(intGridVal.value) )
-							.css({
-								color: C.intToHex( C.toWhite(intGridVal.color,0.5) ),
-								borderColor: C.intToHex( C.toWhite(intGridVal.color,0.2) ),
-								backgroundColor: C.intToHex( C.toBlack(intGridVal.color,0.5) ),
-							});
+						
+						// Value
+						var i = new form.input.IntInput(
+							jValue.find("input.id"),
+							function() return intGridVal.value,
+							function(value) {
+								if( value != null ) {
+									jValue.attr("valueId", Std.string(value));
+									editor.curLevel.getLayerInstance(cur).updateIntGridValue(intGridVal.value, value, false);
+								}
+							}
+						);
+						i.validityCheck = cur.isIntGridValueValid;
+						i.validityError = N.invalidValue;
+						i.onChange = editor.ge.emit.bind(LayerDefChanged(cur.uid, false));
+						i.jInput.css({
+							color: C.intToHex( C.toWhite(intGridVal.color,0.5) ),
+							borderColor: C.intToHex( C.toWhite(intGridVal.color,0.2) ),
+							backgroundColor: C.intToHex( C.toBlack(intGridVal.color,0.5) ),
+						});
 
 						// Tile
 						var jTile = jValue.find(".tile");


### PR DESCRIPTION
This pull request introduces the ability for users to edit `IntGridValueDef` values through an input field, while ensuring proper validation and rule updates.

Closes #1083.

Overview:
 - Changed value indicator to an input field in `editLayerDefs.html`
 - Added `IntInput` to the `value` input field with the following:
   - Validation rule: `LayerDef.isIntGridValueValid` ensures that `0 < value <= 999` and no other `IntGridValueDef` on this layer uses the same `value`.
   - On invalid: Created new notification `invalidValue`.
   - Setter: calls new method, `updateIntGridValue`, on the current layer instance with the old and new value.
 - Added `updateIntGridValue` method to `LayerInstance` which does the following:
   - Updates the `IntGridValueDef` to change the value.
   - Updates all stored values by calling `setIntGrid`.
   - Updates the current layer's definition's auto rules (as the patterns need to be updated with the new value).
   - Updates the auto rules for all levels whose auto source is this layer (not combined with the previous step as the current layer does not have a reference to itself in `autoSourceLayerDefUid`).

Notes:
 - Changing the value indicator to an input field altered the text formatting slightly, but I am unsure how to restore the original formatting. I can look into it further if needed.
 - The range validation is currently handled in `LayerDef.isIntGridValueValid` to centralize the logic across the layer. If preferred, I can refactor this to use `IntInput.setBounds` for inline validation.
 - The `invalidValue` notification uses similar messaging to `invalidIdentifier`. However, I can modify it to explicitly state the value restrictions (e.g., "Value must be a positive integer less than 1000 and unique within the layer.") if you'd prefer a more detailed message.
 - I tried to keep the code style as close as I could to the existing code. Let me know if you have any recommendations.

Example Usage:

Below is an example of updating the `IntGridValueDef`, including verification that changes are properly reflected in the map, auto rules, and when reloading the file.

<details>

Initial IntGrid settings:
![image](https://github.com/user-attachments/assets/96f47317-a2d9-41e1-b096-f9047fd03084)

Selecting the value for the `IntGridValueDef` we want to update:
![image](https://github.com/user-attachments/assets/82c9d87b-60e7-48f2-ba37-6914a8a76ad0)

Changing the value to `2`:
![image](https://github.com/user-attachments/assets/a000790b-20f6-4427-b45b-1fdff304421f)

Verifying that the map has updated:
![image](https://github.com/user-attachments/assets/1e21acef-d9b7-428b-8fcb-64ea8d8c0c48)

Verifying that the rules have updated:
![image](https://github.com/user-attachments/assets/213fb876-153d-4472-ab03-5615c268a1fc)

Verifying that the contents are preserved when loading the file again:
![image](https://github.com/user-attachments/assets/6a35c023-fb8d-4887-a198-c17ae1a6766e)

</details>

---

By submitting this pull request, I hereby assign all copyright and related rights in the changes contained in this pull request to the maintainer(s) of this project, to the extent permitted by law.