### PR TITLE
YSort the Entity array, before rendering

### DIFF
--- a/src/electron.renderer/display/LayerRender.hx
+++ b/src/electron.renderer/display/LayerRender.hx
@@ -176,7 +176,9 @@ class LayerRender {
 
 		case Entities:
 			// Entity layer
-			for(ei in li.entityInstances)
+
+			// Y-Sorting the array.
+			for(ei in li.entityInstances.sort(function(a, b) return a.y - b.y))
 				entityRenders.push( new EntityRender(ei, li.def, renderTarget) );
 
 


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/c07ccf75-2367-4092-8051-794766d3b95d)

After:
![image](https://github.com/user-attachments/assets/518b66b6-2f2c-4ce5-b6a6-249a1312141d)

Before the drawing order was decided by the order in which the entities were placed in the world, now it uses a y-sort.

This is very handy when using entities instead of tilelayers to draw objects.