### PR TITLE
Option to disable level json caching mechanism

### DIFF
--- a/app/assets/tpl/editAppSettings.html
+++ b/app/assets/tpl/editAppSettings.html
@@ -83,6 +83,14 @@
 			</dd>
 
 			<dt>
+				<label for="levelJsonCacheActive">Cache the json levels data for faster editing</label>
+				<info>Disable this if you have issues loading big projects.</info>
+			</dt>
+			<dd>
+				<input type="checkbox" id="levelJsonCacheActive" />
+			</dd>
+
+			<dt>
 				<label for="colorBlind">Prefer color-blind colors</label>
 				<info>Enable this option to use color-blind friendly colors by default for newly created entities, enums or intGrid values.</info>
 			</dt>

--- a/src/electron.common/Settings.hx
+++ b/src/electron.common/Settings.hx
@@ -14,6 +14,7 @@ typedef AppSettings = {
 	var showDetails : Bool;
 	var useBestGPU : Bool;
 	var startFullScreen: Bool;
+	var levelJsonCacheActive: Bool;
 	var autoInstallUpdates : Bool;
 	var colorBlind : Bool;
 	var blurMask : Bool;
@@ -96,6 +97,7 @@ class Settings {
 			showDetails: true,
 			useBestGPU: true,
 			startFullScreen: false,
+			levelJsonCacheActive: true,
 			autoInstallUpdates: true,
 			colorBlind: false,
 			blurMask: true,

--- a/src/electron.renderer/data/Level.hx
+++ b/src/electron.renderer/data/Level.hx
@@ -4,6 +4,7 @@ class Level {
 	var _project : Project;
 	public var _world : World;
 
+	var settings(get,never) : Settings; inline function get_settings() return App.ME.settings;
 	var _cachedJson : Null<{ str:String, json:ldtk.Json.LevelJson }>;
 
 	@:allow(data.Project, data.World)
@@ -379,9 +380,13 @@ class Level {
 	}
 
 	function setJsonCache(json:ldtk.Json.LevelJson, skipHeader:Bool) {
+		if( settings.v.levelJsonCacheActive ) {
 		_cachedJson = {
 			str: ui.ProjectSaver.jsonStringify(_project, json, skipHeader ),
 			json: json,
+			}
+		} else {
+			_cachedJson = null;
 		}
 	}
 

--- a/src/electron.renderer/ui/ProjectLoader.hx
+++ b/src/electron.renderer/ui/ProjectLoader.hx
@@ -158,6 +158,10 @@ class ProjectLoader {
 										var raw = NT.readFileString(path);
 										var lJson = haxe.Json.parse(raw);
 										var l = data.Level.fromJson(p, w, lJson, true);
+										// signal recycling of used values
+										raw = null;
+										lJson = null;
+										// save loaded level data
 										w.levels[curIdx] = l;
 									}
 									catch(e:Dynamic) {

--- a/src/electron.renderer/ui/modal/dialog/EditAppSettings.hx
+++ b/src/electron.renderer/ui/modal/dialog/EditAppSettings.hx
@@ -86,6 +86,13 @@ class EditAppSettings extends ui.modal.Dialog {
 			App.ME.updateBodyClasses();
 		}
 
+		// Levels JSON cache
+		var j = Input.linkToHtmlInput(settings.v.levelJsonCacheActive, jForm.find("#levelJsonCacheActive"));
+		j.onValueChange = (v)->{
+			onSettingChanged();
+			App.ME.updateBodyClasses();
+		}
+
 		// Single layer mode intensity
 		var allValues = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1];
 		if( !allValues.contains(settings.v.singleLayerModeIntensity) ) {


### PR DESCRIPTION
This PR fixes #1172.

When loading projects which are bigger than usual (~40 levels) the level json caching mechanism allocates a lot of memory and requires more than 4GB of memory, which blocks the editor.

The PR adds a new global ui option `levelJsonCacheActive` with default value `true`, that allows create/load these big projects by disabling the caching mechanism.

Included in the change also the UI change to handle the option in line with similar options in the UI already present.

Please review and send feedback.