### PR TITLE
Experiment with level multi-selection in world view, allowing grouped…

### DIFF
--- a/src/electron.renderer/WorldTool.hx
+++ b/src/electron.renderer/WorldTool.hx
@@ -19,6 +19,14 @@ class WorldTool extends dn.Process {
 	var cursor : h2d.Graphics;
 	var clickedSameLevel = false;
 
+	// Multi-selection
+	public var selectedLevels : Array<data.Level>;
+	var selectionRender : h2d.Graphics;
+	var rectSelectionStart : Null<Coords>;
+	var rectSelectionRender : h2d.Graphics;
+	var isRectSelecting = false;
+	var initialLevelPositions : Map<Int, {x:Int, y:Int, neighbours:Array<String>}>;
+
 
 	public function new() {
 		super(Editor.ME);
@@ -28,18 +36,70 @@ class WorldTool extends dn.Process {
 
 		cursor = new h2d.Graphics();
 		editor.worldRender.root.add(cursor, Const.DP_UI);
+
+		// Initialize multi-selection
+		selectedLevels = [];
+		selectionRender = new h2d.Graphics();
+		editor.worldRender.root.add(selectionRender, Const.DP_UI);
+
+		rectSelectionRender = new h2d.Graphics();
+		editor.worldRender.root.add(rectSelectionRender, Const.DP_UI);
+
+		initialLevelPositions = new Map();
 	}
 
 	override function onDispose() {
 		super.onDispose();
 		tmpRender.remove();
 		cursor.remove();
+		selectionRender.remove();
+		rectSelectionRender.remove();
 	}
 
 	@:keep
 	override function toString() {
 		return super.toString()
 			+ ( dragStarted ? " (DRAGGING)" : "" );
+	}
+
+	public function clearSelection() {
+		selectedLevels = [];
+		selectionRender.clear();
+		// Restore yellow highlight when clearing selection
+		editor.worldRender.updateCurrentHighlight();
+	}
+
+	function addToSelection(l:data.Level) {
+		if( !selectedLevels.contains(l) ) {
+			selectedLevels.push(l);
+			updateSelectionRender();
+		}
+	}
+
+	function removeFromSelection(l:data.Level) {
+		selectedLevels.remove(l);
+		updateSelectionRender();
+	}
+
+	function isSelected(l:data.Level) : Bool {
+		return selectedLevels.contains(l);
+	}
+
+	function updateSelectionRender() {
+		selectionRender.clear();
+
+		// Update the yellow highlight visibility (hide it when multi-selecting)
+		editor.worldRender.updateCurrentHighlight();
+
+		if( selectedLevels.length == 0 )
+			return;
+
+		selectionRender.lineStyle(3/editor.camera.adjustedZoom, 0x00ff00, 0.8);
+		selectionRender.beginFill(0x00ff00, 0.15);
+		for( l in selectedLevels ) {
+			selectionRender.drawRect(l.worldX, l.worldY, l.pxWid, l.pxHei);
+		}
+		App.ME.requestCpu(false);
 	}
 
 
@@ -146,9 +206,8 @@ class WorldTool extends dn.Process {
 		}
 
 
-		if( ev.button!=0 || App.ME.isShiftDown() )
+		if( ev.button!=0 )
 			return;
-
 
 		editor.camera.cancelAllAutoMovements();
 
@@ -157,6 +216,15 @@ class WorldTool extends dn.Process {
 		initialNeighbours = null;
 		dragStarted = false;
 		clicked = true;
+
+		// Handle rectangle selection start (with SHIFT for rectangle selection)
+		if( App.ME.isShiftDown() && worldMode ) {
+			rectSelectionStart = m;
+			isRectSelecting = true;
+			ev.cancel = true;
+			return;
+		}
+
 		if( !worldMode && editor.curLevel.inBoundsWorld(m.worldX,m.worldY) )
 			clickedLevel = null;
 		else
@@ -166,61 +234,141 @@ class WorldTool extends dn.Process {
 			clickedLevel = null;
 
 		if( clickedLevel!=null ) {
-			levelOriginX = clickedLevel.worldX;
-			levelOriginY = clickedLevel.worldY;
-			ev.cancel = true;
-			clickedSameLevel = editor.curLevel==clickedLevel;
-			initialNeighbours = clickedLevel.getNeighboursIids();
+			// Handle multi-selection with CTRL/CMD
+			if( App.ME.isCtrlCmdDown() && worldMode ) {
+				if( isSelected(clickedLevel) ) {
+					// Remove from selection
+					removeFromSelection(clickedLevel);
+					if( selectedLevels.length == 0 ) {
+						// If no more selection, revert to single selection
+						editor.selectLevel(clickedLevel);
+					}
+				}
+				else {
+					// Add to selection
+					addToSelection(clickedLevel);
+				}
+				ev.cancel = true;
+				// Still allow dragging with multi-selection
+				levelOriginX = clickedLevel.worldX;
+				levelOriginY = clickedLevel.worldY;
+				clickedSameLevel = editor.curLevel==clickedLevel;
+				initialNeighbours = clickedLevel.getNeighboursIids();
+			}
+			else {
+				// Single click without CTRL/CMD
+				// If clicking on a selected level, keep selection for dragging
+				if( !isSelected(clickedLevel) ) {
+					// Clear selection only if clicking on non-selected level
+					clearSelection();
+					editor.selectLevel(clickedLevel);
+				}
 
-			// Pick level
-			editor.selectLevel(clickedLevel);
+				levelOriginX = clickedLevel.worldX;
+				levelOriginY = clickedLevel.worldY;
+				ev.cancel = true;
+				clickedSameLevel = editor.curLevel==clickedLevel;
+				initialNeighbours = clickedLevel.getNeighboursIids();
+			}
+		}
+		else {
+			// Clicked on empty space - start rectangle selection if in world mode
+			if( worldMode ) {
+				if( !App.ME.isCtrlCmdDown() )
+					clearSelection();
+				rectSelectionStart = m;
+				isRectSelecting = true;
+				ev.cancel = true;
+			}
 		}
 	}
 
 	public function onMouseUp(m:Coords) {
 		tmpRender.clear();
 
-		if( clickedLevel!=null ) {
+		// Handle rectangle selection completion
+		if( isRectSelecting ) {
+			isRectSelecting = false;
+			rectSelectionRender.clear();
+			rectSelectionStart = null;
+		}
+
+		if( clickedLevel!=null || selectedLevels.length > 0 ) {
 			if( dragStarted ) {
-				// Drag complete
-				var initialX = clickedLevel.worldX;
-				var initialY = clickedLevel.worldY;
+				// Drag complete - handle multi-level movement
+				if( selectedLevels.length > 0 ) {
+					// Multi-level movement
+					switch curWorld.worldLayout {
+						case Free, GridVania:
+							curWorld.applyAutoLevelIdentifiers();
+							// Emit events for all moved levels
+							for( uid in initialLevelPositions.keys() ) {
+								var l = project.getLevelAnywhere(uid);
+								if( l != null ) {
+									var data = initialLevelPositions.get(uid);
+									editor.ge.emit( WorldLevelMoved(l, true, data.neighbours) );
+								}
+							}
 
-				switch curWorld.worldLayout {
-					case Free, GridVania:
-						curWorld.applyAutoLevelIdentifiers();
-						editor.ge.emit( WorldLevelMoved(clickedLevel, true, initialNeighbours) );
-
-					case LinearHorizontal:
-						var i = ui.vp.LevelSpotPicker.getLinearInsertPoint(project, curWorld, m, clickedLevel, levelOriginX);
-						if( i!=null ) {
-							var curIdx = dn.Lib.getArrayIndex(clickedLevel, curWorld.levels);
-							var toIdx = i.idx>curIdx ? i.idx-1 : i.idx;
-							curWorld.sortLevel(curIdx, toIdx);
-							curWorld.reorganizeWorld();
-							editor.ge.emit( WorldLevelMoved(clickedLevel, true, initialNeighbours) );
-						}
-
-					case LinearVertical:
-						var i = ui.vp.LevelSpotPicker.getLinearInsertPoint(project, curWorld, m, clickedLevel, levelOriginY);
-						if( i!=null ) {
-							var curIdx = dn.Lib.getArrayIndex(clickedLevel, curWorld.levels);
-							var toIdx = i.idx>curIdx ? i.idx-1 : i.idx;
-							curWorld.sortLevel(curIdx, toIdx);
-							curWorld.reorganizeWorld();
-							editor.ge.emit( WorldLevelMoved(clickedLevel, true, initialNeighbours) );
-						}
+						case LinearHorizontal, LinearVertical:
+							// For linear layouts, only single level movement is supported
+							if( clickedLevel != null ) {
+								if( curWorld.worldLayout == LinearHorizontal ) {
+									var i = ui.vp.LevelSpotPicker.getLinearInsertPoint(project, curWorld, m, clickedLevel, levelOriginX);
+									if( i!=null ) {
+										var curIdx = dn.Lib.getArrayIndex(clickedLevel, curWorld.levels);
+										var toIdx = i.idx>curIdx ? i.idx-1 : i.idx;
+										curWorld.sortLevel(curIdx, toIdx);
+										curWorld.reorganizeWorld();
+										editor.ge.emit( WorldLevelMoved(clickedLevel, true, initialNeighbours) );
+									}
+								}
+								else {
+									var i = ui.vp.LevelSpotPicker.getLinearInsertPoint(project, curWorld, m, clickedLevel, levelOriginY);
+									if( i!=null ) {
+										var curIdx = dn.Lib.getArrayIndex(clickedLevel, curWorld.levels);
+										var toIdx = i.idx>curIdx ? i.idx-1 : i.idx;
+										curWorld.sortLevel(curIdx, toIdx);
+										curWorld.reorganizeWorld();
+										editor.ge.emit( WorldLevelMoved(clickedLevel, true, initialNeighbours) );
+									}
+								}
+							}
+					}
 				}
+				else if( clickedLevel != null ) {
+					// Single level movement (original behavior)
+					switch curWorld.worldLayout {
+						case Free, GridVania:
+							curWorld.applyAutoLevelIdentifiers();
+							editor.ge.emit( WorldLevelMoved(clickedLevel, true, initialNeighbours) );
 
+						case LinearHorizontal:
+							var i = ui.vp.LevelSpotPicker.getLinearInsertPoint(project, curWorld, m, clickedLevel, levelOriginX);
+							if( i!=null ) {
+								var curIdx = dn.Lib.getArrayIndex(clickedLevel, curWorld.levels);
+								var toIdx = i.idx>curIdx ? i.idx-1 : i.idx;
+								curWorld.sortLevel(curIdx, toIdx);
+								curWorld.reorganizeWorld();
+								editor.ge.emit( WorldLevelMoved(clickedLevel, true, initialNeighbours) );
+							}
+
+						case LinearVertical:
+							var i = ui.vp.LevelSpotPicker.getLinearInsertPoint(project, curWorld, m, clickedLevel, levelOriginY);
+							if( i!=null ) {
+								var curIdx = dn.Lib.getArrayIndex(clickedLevel, curWorld.levels);
+								var toIdx = i.idx>curIdx ? i.idx-1 : i.idx;
+								curWorld.sortLevel(curIdx, toIdx);
+								curWorld.reorganizeWorld();
+								editor.ge.emit( WorldLevelMoved(clickedLevel, true, initialNeighbours) );
+							}
+					}
+				}
 			}
-			else if( !worldMode && getLevelAt(m.worldX, m.worldY)==clickedLevel || origin.getPageDist(m)<=getDragThreshold() ) {
-			// 	// Pick level
-			// 	editor.selectLevel(clickedLevel);
-				// Enter level on "double-click"
-				if( clickedSameLevel )
+			else if( clickedLevel!=null && (!worldMode && getLevelAt(m.worldX, m.worldY)==clickedLevel || origin.getPageDist(m)<=getDragThreshold()) ) {
+				// Enter level on "double-click" - but not if we were selecting with CTRL/CMD
+				if( clickedSameLevel && !App.ME.isCtrlCmdDown() )
 					editor.setWorldMode(false);
-			// 	else if( !worldMode )
-			// 		editor.camera.scrollTo(m.worldX, m.worldY);
 			}
 		}
 
@@ -228,9 +376,10 @@ class WorldTool extends dn.Process {
 		clickedLevel = null;
 		dragStarted = false;
 		clicked = false;
+		initialLevelPositions.clear();
 	}
 
-	inline function getLevelSnapDist() return App.ME.isShiftDown() || App.ME.isCtrlCmdDown() ? 0 : project.getSmartLevelGridSize() / ( editor.camera.adjustedZoom * 0.4 );
+	inline function getLevelSnapDist() return App.ME.isAltDown() ? 0 : project.getSmartLevelGridSize() / ( editor.camera.adjustedZoom * 0.4 );
 
 	inline function snapLevelX(cur:data.Level, offset:Int, at:Int) {
 		if( M.fabs(cur.worldX + offset - at) <= getLevelSnapDist() ) {
@@ -267,15 +416,28 @@ class WorldTool extends dn.Process {
 			return;
 		}
 
+		// Don't show yellow cursor if we have multi-selection
+		if( selectedLevels.length > 0 ) {
+			cursor.clear();
+			return;
+		}
+
 		// Rollover
 		var over = getLevelAt(m.worldX, m.worldY, worldMode?null:editor.curLevel);
 		if( over!=null ) {
 			ev.cancel = true;
 			cursor.clear();
 			editor.cursor.set(Pointer);
-			cursor.lineStyle(2/editor.camera.adjustedZoom, 0xffffff);
-			cursor.beginFill(0xffcc00, 0.15);
-			// var p = project.getSmartLevelGridSize()*0.5;
+
+			// Different color if level is already selected
+			if( isSelected(over) ) {
+				cursor.lineStyle(2/editor.camera.adjustedZoom, 0x00ff00);
+				cursor.beginFill(0x00ff00, 0.15);
+			}
+			else {
+				cursor.lineStyle(2/editor.camera.adjustedZoom, 0xffffff);
+				cursor.beginFill(0xffcc00, 0.15);
+			}
 			cursor.drawRect(over.worldX, over.worldY, over.pxWid, over.pxHei);
 			ev.cancel = true;
 			App.ME.requestCpu(false);
@@ -285,30 +447,123 @@ class WorldTool extends dn.Process {
 	}
 
 	public function onMouseMove(ev:hxd.Event, m:Coords) {
+		// Handle rectangle selection
+		if( isRectSelecting && rectSelectionStart != null ) {
+			rectSelectionRender.clear();
+			rectSelectionRender.lineStyle(2/editor.camera.adjustedZoom, 0x00ff00, 0.8);
+			rectSelectionRender.beginFill(0x00ff00, 0.2);
+
+			var x1 = M.fmin(rectSelectionStart.worldX, m.worldX);
+			var y1 = M.fmin(rectSelectionStart.worldY, m.worldY);
+			var x2 = M.fmax(rectSelectionStart.worldX, m.worldX);
+			var y2 = M.fmax(rectSelectionStart.worldY, m.worldY);
+
+			rectSelectionRender.drawRect(x1, y1, x2-x1, y2-y1);
+
+			// Find levels within rectangle
+			var newSelection = [];
+			for( l in curWorld.levels ) {
+				if( l.worldDepth == editor.curWorldDepth &&
+					l.worldX < x2 && l.worldX + l.pxWid > x1 &&
+					l.worldY < y2 && l.worldY + l.pxHei > y1 ) {
+					newSelection.push(l);
+				}
+			}
+
+			// Update selection
+			if( !App.ME.isCtrlCmdDown() )
+				selectedLevels = [];
+			for( l in newSelection )
+				if( !isSelected(l) )
+					selectedLevels.push(l);
+			updateSelectionRender();
+
+			ev.cancel = true;
+			App.ME.requestCpu();
+			return;
+		}
+
 		// Start dragging
 		if( clicked && worldMode && !dragStarted && origin.getPageDist(m)>=getDragThreshold() ) {
 			var allow = switch curWorld.worldLayout {
 				case Free: true;
 				case GridVania: true;
-				case LinearHorizontal, LinearVertical: curWorld.levels.length>1;
+				case LinearHorizontal, LinearVertical: selectedLevels.length==0 && curWorld.levels.length>1;
 			}
 			if( allow ) {
 				dragStarted = true;
 				ev.cancel = true;
-				// if( clickedLevel!=null )
-				// 	editor.selectLevel(clickedLevel);
 
+				// Initialize positions for all selected levels
+				initialLevelPositions.clear();
+
+				// If we have a clicked level but no selection, treat it as single selection
+				if( clickedLevel != null && selectedLevels.length == 0 ) {
+					// Single level drag
+					initialLevelPositions.set(clickedLevel.uid, {
+						x: clickedLevel.worldX,
+						y: clickedLevel.worldY,
+						neighbours: clickedLevel.getNeighboursIids()
+					});
+				}
+				else if( selectedLevels.length > 0 ) {
+					// Multi-level drag
+					// Include clicked level in selection if not already
+					if( clickedLevel != null && !isSelected(clickedLevel) ) {
+						addToSelection(clickedLevel);
+					}
+
+					// Store initial positions for all selected levels
+					for( l in selectedLevels ) {
+						initialLevelPositions.set(l.uid, {
+							x: l.worldX,
+							y: l.worldY,
+							neighbours: l.getNeighboursIids()
+						});
+					}
+				}
+
+				// Handle duplication with Alt+Ctrl
 				if( clickedLevel!=null && App.ME.isAltDown() && App.ME.isCtrlCmdDown() ) {
-					var copy = curWorld.duplicateLevel(clickedLevel);
-					editor.ge.emit( LevelAdded(copy) );
-					editor.selectLevel(copy);
-					clickedLevel = copy;
+					if( selectedLevels.length > 0 ) {
+						// Duplicate all selected levels
+						var newSelection = [];
+						for( l in selectedLevels ) {
+							var copy = curWorld.duplicateLevel(l);
+							editor.ge.emit( LevelAdded(copy) );
+							newSelection.push(copy);
+							// Update initial positions for the copies
+							initialLevelPositions.set(copy.uid, {
+								x: copy.worldX,
+								y: copy.worldY,
+								neighbours: copy.getNeighboursIids()
+							});
+						}
+						selectedLevels = newSelection;
+						if( clickedLevel != null ) {
+							// Find the copy of the clicked level
+							for( l in newSelection ) {
+								if( l.worldX == clickedLevel.worldX + project.defaultGridSize*4 &&
+									l.worldY == clickedLevel.worldY + project.defaultGridSize*4 ) {
+									clickedLevel = l;
+									editor.selectLevel(l);
+									break;
+								}
+							}
+						}
+					}
+					else {
+						var copy = curWorld.duplicateLevel(clickedLevel);
+						editor.ge.emit( LevelAdded(copy) );
+						editor.selectLevel(copy);
+						clickedLevel = copy;
+					}
 				}
 			}
 		}
 
 		// Drag
-		if( clickedLevel!=null && dragStarted ) {
+		if( (clickedLevel!=null || selectedLevels.length > 0) && dragStarted ) {
 			// Init tmpRender render
 			tmpRender.clear();
 			tmpRender.lineStyle(10, 0x72feff, 0.5);
@@ -326,65 +581,159 @@ class WorldTool extends dn.Process {
 				case LinearHorizontal: false;
 				case LinearVertical: true;
 			}
-			var initialX = clickedLevel.worldX;
-			var initialY = clickedLevel.worldY;
-			if( allowX )
-				clickedLevel.worldX = levelOriginX + ( m.worldX - origin.worldX );
-			else
-				clickedLevel.worldX = Std.int( -clickedLevel.pxWid*0.8 );
 
-			if( allowY )
-				clickedLevel.worldY = levelOriginY + ( m.worldY - origin.worldY );
-			else
-				clickedLevel.worldY = Std.int( -clickedLevel.pxHei*0.8 );
+			// Calculate offset based on clicked level or first selected level
+			var offsetX = m.worldX - origin.worldX;
+			var offsetY = m.worldY - origin.worldY;
+
+			// Move multiple selected levels
+			if( selectedLevels.length > 0 ) {
+				for( l in selectedLevels ) {
+					var initData = initialLevelPositions.get(l.uid);
+					if( initData != null ) {
+						if( allowX )
+							l.worldX = initData.x + offsetX;
+						else
+							l.worldX = Std.int( -l.pxWid*0.8 );
+
+						if( allowY )
+							l.worldY = initData.y + offsetY;
+						else
+							l.worldY = Std.int( -l.pxHei*0.8 );
+					}
+				}
+			}
+			else if( clickedLevel != null ) {
+				// Single level movement (original behavior)
+				var initialX = clickedLevel.worldX;
+				var initialY = clickedLevel.worldY;
+				if( allowX )
+					clickedLevel.worldX = levelOriginX + offsetX;
+				else
+					clickedLevel.worldX = Std.int( -clickedLevel.pxWid*0.8 );
+
+				if( allowY )
+					clickedLevel.worldY = levelOriginY + offsetY;
+				else
+					clickedLevel.worldY = Std.int( -clickedLevel.pxHei*0.8 );
+			}
 
 			switch curWorld.worldLayout {
 				case Free:
-					// Snap to grid
-					if( settings.v.grid ) {
-						var g = project.getSmartLevelGridSize();
-						clickedLevel.worldX = Std.int( clickedLevel.worldX/g ) * g;
-						clickedLevel.worldY = Std.int( clickedLevel.worldY/g ) * g;
+					if( selectedLevels.length > 0 ) {
+						// Multi-level snapping: snap as a group using the clicked level as reference
+						if( clickedLevel != null ) {
+							var snapDeltaX = 0;
+							var snapDeltaY = 0;
+
+							// Snap to grid using clicked level
+							if( settings.v.grid ) {
+								var g = project.getSmartLevelGridSize();
+								var snappedX = Std.int( clickedLevel.worldX/g ) * g;
+								var snappedY = Std.int( clickedLevel.worldY/g ) * g;
+								snapDeltaX = snappedX - clickedLevel.worldX;
+								snapDeltaY = snappedY - clickedLevel.worldY;
+							}
+
+							// Check snapping to other levels (not in selection)
+							for(l in curWorld.levels) {
+								if( selectedLevels.contains(l) )
+									continue;
+
+								// Check each selected level for snapping, but apply uniformly
+								for( snapLevel in selectedLevels ) {
+									if( snapLevel.getBoundsDist(l) > getLevelSnapDist() )
+										continue;
+
+									// Try X snapping
+									var oldX = snapLevel.worldX;
+									if( snapLevelX(snapLevel, 0, l.worldX) ||
+										snapLevelX(snapLevel, 0, l.worldX+l.pxWid) ||
+										snapLevelX(snapLevel, snapLevel.pxWid, l.worldX) ||
+										snapLevelX(snapLevel, snapLevel.pxWid, l.worldX+l.pxWid) ) {
+										snapDeltaX = snapLevel.worldX - oldX;
+									}
+									snapLevel.worldX = oldX; // Reset for now
+
+									// Try Y snapping
+									var oldY = snapLevel.worldY;
+									if( snapLevelY(snapLevel, 0, l.worldY) ||
+										snapLevelY(snapLevel, 0, l.worldY+l.pxHei) ||
+										snapLevelY(snapLevel, snapLevel.pxHei, l.worldY) ||
+										snapLevelY(snapLevel, snapLevel.pxHei, l.worldY+l.pxHei) ) {
+										snapDeltaY = snapLevel.worldY - oldY;
+									}
+									snapLevel.worldY = oldY; // Reset
+								}
+							}
+
+							// Apply snap delta uniformly to all selected levels
+							if( snapDeltaX != 0 || snapDeltaY != 0 ) {
+								for( l in selectedLevels ) {
+									l.worldX += snapDeltaX;
+									l.worldY += snapDeltaY;
+								}
+							}
+						}
 					}
+					else if( clickedLevel != null ) {
+						// Single level snapping (original behavior)
+						// Snap to grid
+						if( settings.v.grid ) {
+							var g = project.getSmartLevelGridSize();
+							clickedLevel.worldX = Std.int( clickedLevel.worldX/g ) * g;
+							clickedLevel.worldY = Std.int( clickedLevel.worldY/g ) * g;
+						}
 
-					// Snap to other levels
-					for(l in curWorld.levels) {
-						if( l==clickedLevel )
-							continue;
+						// Snap to other levels
+						for(l in curWorld.levels) {
+							if( l==clickedLevel )
+								continue;
 
-						if( clickedLevel.getBoundsDist(l) > getLevelSnapDist() )
-							continue;
+							if( clickedLevel.getBoundsDist(l) > getLevelSnapDist() )
+								continue;
 
-						// X
-						snapLevelX(clickedLevel, 0, l.worldX);
-						snapLevelX(clickedLevel, 0, l.worldX+l.pxWid);
-						snapLevelX(clickedLevel, clickedLevel.pxWid, l.worldX);
-						snapLevelX(clickedLevel, clickedLevel.pxWid, l.worldX+l.pxWid);
+							// X
+							snapLevelX(clickedLevel, 0, l.worldX);
+							snapLevelX(clickedLevel, 0, l.worldX+l.pxWid);
+							snapLevelX(clickedLevel, clickedLevel.pxWid, l.worldX);
+							snapLevelX(clickedLevel, clickedLevel.pxWid, l.worldX+l.pxWid);
 
-						// Y
-						snapLevelY(clickedLevel, 0, l.worldY);
-						snapLevelY(clickedLevel, 0, l.worldY+l.pxHei);
-						snapLevelY(clickedLevel, clickedLevel.pxHei, l.worldY);
-						snapLevelY(clickedLevel, clickedLevel.pxHei, l.worldY+l.pxHei);
+							// Y
+							snapLevelY(clickedLevel, 0, l.worldY);
+							snapLevelY(clickedLevel, 0, l.worldY+l.pxHei);
+							snapLevelY(clickedLevel, clickedLevel.pxHei, l.worldY);
+							snapLevelY(clickedLevel, clickedLevel.pxHei, l.worldY+l.pxHei);
 
-						// X again because if Y snapped, X snapping result might change
-						snapLevelX(clickedLevel, 0, l.worldX);
-						snapLevelX(clickedLevel, 0, l.worldX+l.pxWid);
-						snapLevelX(clickedLevel, clickedLevel.pxWid, l.worldX);
-						snapLevelX(clickedLevel, clickedLevel.pxWid, l.worldX+l.pxWid);
+							// X again because if Y snapped, X snapping result might change
+							snapLevelX(clickedLevel, 0, l.worldX);
+							snapLevelX(clickedLevel, 0, l.worldX+l.pxWid);
+							snapLevelX(clickedLevel, clickedLevel.pxWid, l.worldX);
+							snapLevelX(clickedLevel, clickedLevel.pxWid, l.worldX+l.pxWid);
+						}
 					}
 
 				case GridVania:
-					var omx = M.floor( origin.worldX / curWorld.worldGridWidth ) * curWorld.worldGridWidth;
-					var mx = M.floor( m.worldX / curWorld.worldGridWidth ) * curWorld.worldGridWidth;
-					clickedLevel.worldX = levelOriginX + (mx-omx);
+					if( selectedLevels.length > 0 ) {
+						// Multi-level snapping for GridVania
+						if( clickedLevel != null ) {
+							var snappedX = M.floor( clickedLevel.worldX/curWorld.worldGridWidth ) * curWorld.worldGridWidth;
+							var snappedY = M.floor( clickedLevel.worldY/curWorld.worldGridHeight ) * curWorld.worldGridHeight;
+							var snapDeltaX = snappedX - clickedLevel.worldX;
+							var snapDeltaY = snappedY - clickedLevel.worldY;
 
-					var omy = M.floor( origin.worldY / curWorld.worldGridHeight ) * curWorld.worldGridHeight;
-					var my = M.floor( m.worldY / curWorld.worldGridHeight ) * curWorld.worldGridHeight;
-					clickedLevel.worldY = levelOriginY + (my-omy);
-
-					clickedLevel.worldX = M.floor( clickedLevel.worldX/curWorld.worldGridWidth ) * curWorld.worldGridWidth;
-					clickedLevel.worldY = M.floor( clickedLevel.worldY/curWorld.worldGridHeight ) * curWorld.worldGridHeight;
+							// Apply uniform snapping to all selected levels
+							for( l in selectedLevels ) {
+								l.worldX += snapDeltaX;
+								l.worldY += snapDeltaY;
+							}
+						}
+					}
+					else if( clickedLevel != null ) {
+						// Single level snapping
+						clickedLevel.worldX = M.floor( clickedLevel.worldX/curWorld.worldGridWidth ) * curWorld.worldGridWidth;
+						clickedLevel.worldY = M.floor( clickedLevel.worldY/curWorld.worldGridHeight ) * curWorld.worldGridHeight;
+					}
 
 				case LinearHorizontal:
 					var i = ui.vp.LevelSpotPicker.getLinearInsertPoint(project, curWorld, m, clickedLevel, levelOriginX);
@@ -401,8 +750,16 @@ class WorldTool extends dn.Process {
 					}
 			}
 
-			// Refresh render
-			editor.ge.emit( WorldLevelMoved(clickedLevel, false, null) );
+			// Refresh render for all moved levels
+			if( selectedLevels.length > 0 ) {
+				for( l in selectedLevels )
+					editor.ge.emit( WorldLevelMoved(l, false, null) );
+				// Update selection visualization during drag
+				updateSelectionRender();
+			}
+			else if( clickedLevel != null )
+				editor.ge.emit( WorldLevelMoved(clickedLevel, false, null) );
+
 			App.ME.requestCpu();
 			ev.cancel = true;
 		}

--- a/src/electron.renderer/display/WorldRender.hx
+++ b/src/electron.renderer/display/WorldRender.hx
@@ -652,9 +652,10 @@ class WorldRender extends dn.Process {
 		);
 	}
 
-	function updateCurrentHighlight() {
+	public function updateCurrentHighlight() {
 		final l = editor.curLevel;
-		currentHighlight.visible = editor.worldMode && l.worldDepth==editor.curWorldDepth;
+		// Hide yellow highlight if we have a multi-selection
+		currentHighlight.visible = editor.worldMode && l.worldDepth==editor.curWorldDepth && editor.worldTool.selectedLevels.length == 0;
 		if( !currentHighlight.visible )
 			return;
 

--- a/src/electron.renderer/page/Editor.hx
+++ b/src/electron.renderer/page/Editor.hx
@@ -1353,6 +1353,7 @@ class Editor extends Page {
 		if( worldMode )
 			setWorldMode(false);
 
+		worldTool.clearSelection(); // Clear multi-level selection when switching worlds
 		curWorldIid = w.iid;
 		invalidateCachedLevelErrors();
 
@@ -1685,6 +1686,7 @@ class Editor extends Page {
 
 		App.ME.requestCpu();
 		selectionTool.clear();
+		worldTool.clearSelection(); // Clear multi-level selection
 		curWorld.reorganizeWorld();
 		curLevel.invalidateCachedError();
 		worldMode = v;


### PR DESCRIPTION
This PR adds support of selecting multiple levels to move them together within the world view (in free and gridvania modes) as showcased here: https://discord.com/channels/761549092677353513/761549093461295127/1427344800322949321

The multi-selection is possible either with rectangle selection or by pressing CMD/CTRL and click on the levels.

So far, didn't experience any issue after the change, so hopefully I didn't break anything!