### PR TITLE
Date-based id generation

### DIFF
--- a/src/electron.renderer/data/Project.hx
+++ b/src/electron.renderer/data/Project.hx
@@ -225,7 +225,10 @@ class Project {
 		return iid;
 	}
 
-	public function generateUniqueId_int() return nextUid++ + Std.int(Date.now().getTime());
+	public function generateUniqueId_int(): Int {
+		var oldDate = new Date(2020, 1, 1, 0, 0, 0); // 2020 date
+		return nextUid++ + Std.int(Date.now().getTime() - oldDate.getTime());
+	}
 
 	public function fixUniqueIdStr(baseId:String, ?styleOverride:ldtk.Json.IdentifierStyle, isUnique:String->Bool) : String {
 		baseId = cleanupIdentifier(baseId, styleOverride==null ? identifierStyle : styleOverride);

--- a/src/electron.renderer/data/Project.hx
+++ b/src/electron.renderer/data/Project.hx
@@ -225,7 +225,7 @@ class Project {
 		return iid;
 	}
 
-	public function generateUniqueId_int() return nextUid++;
+	public function generateUniqueId_int() return nextUid++ + Std.int(Date.now().getTime());
 
 	public function fixUniqueIdStr(baseId:String, ?styleOverride:ldtk.Json.IdentifierStyle, isUnique:String->Bool) : String {
 		baseId = cleanupIdentifier(baseId, styleOverride==null ? identifierStyle : styleOverride);


### PR DESCRIPTION
This PR is just a cherry pick of @BretHudson's changes to generate ids.

The way the id is generated could probably be improved further, like by adding some actual randomness that is not depending on current time, in addition to the date-based logic, but I preferred to keep the changes as is.

Feel free to update the branch directly (you can push to it) if you have a better idea in how ids should be generated here.