### PR TITLE
Fix LocaleString imports for updated deepnightLibs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,20 @@ Visit [LDtk.io](https://ldtk.io) to get latest version.
 
 ## Requirements
 
- - **[Haxe compiler](https://haxe.org)**: you need an up-to-date and working Haxe install  to build LDtk.
- - **[NPM](https://nodejs.org/en/download/)**: this package manager is used for various install and packaging scripts. It is packaged with NodeJS.
+- **[Haxe compiler](https://haxe.org)**: you need an up-to-date and working Haxe install  to build LDtk.
+- **[NPM](https://nodejs.org/en/download/)**: this package manager is used for various install and packaging scripts. It is packaged with NodeJS.
 
 ## Installing required stuff
 
- - Open a command line **in the `ldtk` root dir**,
- - Install required Haxe libs:
+- Open a command line **in the `ldtk` root dir**,
+- Install required Haxe libs:
+
  ```
  haxe setup.hxml
  ```
- - Install Electron locally and other dependencies through NPM (**IMPORTANT**: you need to be in the `app` dir):
+
+- Install Electron locally and other dependencies through NPM (**IMPORTANT**: you need to be in the `app` dir):
+
  ```
  cd app
  npm i
@@ -56,9 +59,10 @@ This should create `app/assets/js/renderer.js`.
 If you want to try a future version of LDtk, you can checkout branches named `dev-x.y.z` where x.y.z is version number.
 
 **IMPORTANT**:
- - these *dev* branches might be unstables, or even broken. Therefore, it's not recommended to use, unless you plan to add or fix something on LDtk.
- - because *dev* branches might change quickly, you will need to update haxelibs often.
- - you will need to switch the *LDtk haxe API* to the **same** branch as LDtk repo. (adapt the branch name below accordingly):
+
+- these *dev* branches might be unstables, or even broken. Therefore, it's not recommended to use, unless you plan to add or fix something on LDtk.
+- because *dev* branches might change quickly, you will need to update haxelibs often.
+- you will need to switch the *LDtk haxe API* to the **same** branch as LDtk repo. (adapt the branch name below accordingly):
 
 ```
 haxelib git ldtk-haxe-api https://github.com/deepnight/ldtk-haxe-api.git dev-0.6.0
@@ -75,16 +79,16 @@ npm run start
 # Contributing
 
 You can read the general Pull Request guidelines here:
-https://github.com/deepnight/ldtk/wiki#pull-request-guidelines
+<https://github.com/deepnight/ldtk/wiki#pull-request-guidelines>
 
 # Related tools & licences
 
- - Tileset images: see [README](app/extraFiles/samples/README.md) in samples
- - Haxe: https://haxe.org/
- - Heaps.io: https://heaps.io/
- - Electron: https://www.electronjs.org/
- - JQuery: https://jquery.com
- - MarkedJS: https://github.com/markedjs/marked
- - SVG icons from https://material.io
- - Default palette: "*Endesga32*" by Endesga (https://lospec.com/palette-list/endesga-32)
- - Default color blind palette: "*Colorblind 16*" by FilipWorks (https://github.com/filipworksdev/colorblind-palette-16)
+- Tileset images: see [README](app/extraFiles/samples/README.md) in samples
+- Haxe: <https://haxe.org/>
+- Heaps.io: <https://heaps.io/>
+- Electron: <https://www.electronjs.org/>
+- JQuery: <https://jquery.com>
+- MarkedJS: <https://github.com/markedjs/marked>
+- SVG icons from <https://material.io>
+- Default palette: "*Endesga32*" by Endesga (<https://lospec.com/palette-list/endesga-32>)
+- Default color blind palette: "*Colorblind 16*" by FilipWorks (<https://github.com/filipworksdev/colorblind-palette-16>)

--- a/src/electron.renderer/Lang.hx
+++ b/src/electron.renderer/Lang.hx
@@ -1,4 +1,5 @@
 import dn.data.GetText;
+import dn.data.LocaleString;
 
 class Lang {
 	// Text constants

--- a/src/electron.renderer/form/Input.hx
+++ b/src/electron.renderer/form/Input.hx
@@ -1,5 +1,7 @@
 package form;
 
+import dn.data.LocaleString;
+
 #if macro
 import haxe.macro.Expr;
 import haxe.macro.Context;

--- a/src/electron.renderer/form/input/EnumSelect.hx
+++ b/src/electron.renderer/form/input/EnumSelect.hx
@@ -1,10 +1,12 @@
 package form.input;
 
+import dn.data.LocaleString;
+
 class EnumSelect<T:EnumValue> extends form.Input<T> {
 	var enumRef : Enum<T>;
 	var allowNull : Bool;
 
-	public function new(j:js.jquery.JQuery, e:Enum<T>, allowNull=false, getter:Void->T, setter:T->Void, ?nameLocalizer:T->dn.data.GetText.LocaleString, ?keepOnly:T->Bool, disableFilteredOuts=false) {
+	public function new(j:js.jquery.JQuery, e:Enum<T>, allowNull=false, getter:Void->T, setter:T->Void, ?nameLocalizer:T->LocaleString, ?keepOnly:T->Bool, disableFilteredOuts=false) {
 		this.allowNull = allowNull;
 
 		super(j, getter, setter);

--- a/src/electron.renderer/page/Editor.hx
+++ b/src/electron.renderer/page/Editor.hx
@@ -1,5 +1,7 @@
 package page;
 
+import dn.data.LocaleString;
+
 class Editor extends Page {
 	public static var ME : Editor;
 
@@ -2549,7 +2551,7 @@ class Editor extends Page {
 		var jGuide = new J("#guide");
 		jGuide.empty();
 
-		function _createGuideBlock(?keys:Array<Int>, mouseIconId:Null<String>, label:dn.data.GetText.LocaleString) {
+		function _createGuideBlock(?keys:Array<Int>, mouseIconId:Null<String>, label:LocaleString) {
 			var block = new J('<span/>');
 			block.appendTo(jGuide);
 

--- a/src/electron.renderer/ui/LastChance.hx
+++ b/src/electron.renderer/ui/LastChance.hx
@@ -1,10 +1,12 @@
 package ui;
 
+import dn.data.LocaleString;
+
 class LastChance extends dn.Process {
 	static var CUR : Null<LastChance>;
 	var elem : js.jquery.JQuery;
 
-	public function new(str:dn.data.GetText.LocaleString, project:data.Project) {
+	public function new(str:LocaleString, project:data.Project) {
 		super(Editor.ME);
 
 		LastChance.end();

--- a/src/electron.renderer/ui/ProjectSaver.hx
+++ b/src/electron.renderer/ui/ProjectSaver.hx
@@ -1,5 +1,7 @@
 package ui;
 
+import dn.data.LocaleString;
+
 private enum SavingState {
 	/* !! WARNING !! The ordering of this enum is used by beginNextState()!  */
 	InQueue;

--- a/src/electron.renderer/ui/modal/ContextMenu.hx
+++ b/src/electron.renderer/ui/modal/ContextMenu.hx
@@ -1,6 +1,6 @@
 package ui.modal;
 
-import dn.data.GetText.LocaleString;
+import dn.data.LocaleString;
 
 typedef ContextActions = Array<ContextAction>;
 typedef ContextAction = {

--- a/src/electron.renderer/ui/modal/Dialog.hx
+++ b/src/electron.renderer/ui/modal/Dialog.hx
@@ -1,5 +1,7 @@
 package ui.modal;
 
+import dn.data.LocaleString;
+
 class Dialog extends ui.Modal {
 	var jButtons: js.jquery.JQuery;
 
@@ -40,7 +42,7 @@ class Dialog extends ui.Modal {
 	}
 
 
-	public function addTitle(label:dn.data.GetText.LocaleString, atTheBeginning:Bool) {
+	public function addTitle(label:LocaleString, atTheBeginning:Bool) {
 		var t = new J('<h2>$label</h2>');
 		if( atTheBeginning )
 			jContent.prepend(t);
@@ -48,14 +50,14 @@ class Dialog extends ui.Modal {
 			jContent.append(t);
 	}
 
-	public function addParagraph(str:dn.data.GetText.LocaleString, ?className:String) {
+	public function addParagraph(str:LocaleString, ?className:String) {
 		var jElem = new J('<p>$str</p>');
 		if( className!=null )
 			jElem.addClass(className);
 		jContent.append(jElem);
 	}
 
-	public function addDiv(str:dn.data.GetText.LocaleString, ?className:String) {
+	public function addDiv(str:LocaleString, ?className:String) {
 		var jElem = new J('<div>$str</div>');
 		if( className!=null )
 			jElem.addClass(className);

--- a/src/electron.renderer/ui/modal/dialog/Choice.hx
+++ b/src/electron.renderer/ui/modal/dialog/Choice.hx
@@ -1,5 +1,7 @@
 package ui.modal.dialog;
 
+import dn.data.LocaleString;
+
 class Choice extends ui.modal.Dialog {
 	public function new(str:LocaleString, choices:Array<{ label:String, cb:Void->Void, ?cond:Void->Bool, ?className:String }>, ?title:LocaleString, canCancel=true, ?onCancel:Void->Void) {
 		super();

--- a/src/electron.renderer/ui/modal/dialog/Confirm.hx
+++ b/src/electron.renderer/ui/modal/dialog/Confirm.hx
@@ -1,5 +1,7 @@
 package ui.modal.dialog;
 
+import dn.data.LocaleString;
+
 class Confirm extends ui.modal.Dialog {
 	var onConfirm : Null<Void->Void>;
 	var onCancel : Null<Void->Void>;

--- a/src/electron.renderer/ui/modal/dialog/InputDialog.hx
+++ b/src/electron.renderer/ui/modal/dialog/InputDialog.hx
@@ -1,5 +1,7 @@
 package ui.modal.dialog;
 
+import dn.data.LocaleString;
+
 class InputDialog<T> extends ui.modal.Dialog {
 	var jValidate : js.jquery.JQuery;
 	var jInput : js.jquery.JQuery;
@@ -8,7 +10,7 @@ class InputDialog<T> extends ui.modal.Dialog {
 	var parser : String->T;
 	var onConfirm : T->Void;
 
-	public function new(desc:dn.data.GetText.LocaleString, ?curValue:T, ?suffix="", ?getError:T->Null<String>, parser:String->T, onConfirm:T->Void) {
+	public function new(desc:LocaleString, ?curValue:T, ?suffix="", ?getError:T->Null<String>, parser:String->T, onConfirm:T->Void) {
 		super("inputDialog");
 
 		this.getError = getError;

--- a/src/electron.renderer/ui/modal/dialog/LockMessage.hx
+++ b/src/electron.renderer/ui/modal/dialog/LockMessage.hx
@@ -3,7 +3,7 @@ package ui.modal.dialog;
 class LockMessage extends ui.modal.Dialog {
 	static var ME : LockMessage;
 
-	public function new(str:dn.data.GetText.LocaleString, action:Void->Void) {
+	public function new(str:LocaleString, action:Void->Void) {
 		super("lockMessage");
 
 		ME = this;

--- a/src/electron.renderer/ui/modal/dialog/LogPrint.hx
+++ b/src/electron.renderer/ui/modal/dialog/LogPrint.hx
@@ -1,5 +1,7 @@
 package ui.modal.dialog;
 
+import dn.data.LocaleString;
+
 class LogPrint extends ui.modal.Dialog {
 	var log : dn.Log;
 

--- a/src/electron.renderer/ui/modal/dialog/Message.hx
+++ b/src/electron.renderer/ui/modal/dialog/Message.hx
@@ -1,7 +1,9 @@
 package ui.modal.dialog;
 
+import dn.data.LocaleString;
+
 class Message extends ui.modal.Dialog {
-	public function new(?str:dn.data.GetText.LocaleString, ?iconId:String, ?onClose:Void->Void) {
+	public function new(?str:LocaleString, ?iconId:String, ?onClose:Void->Void) {
 		super("message");
 
 		if( iconId!=null ) {

--- a/src/electron.renderer/ui/modal/dialog/Retry.hx
+++ b/src/electron.renderer/ui/modal/dialog/Retry.hx
@@ -1,7 +1,9 @@
 package ui.modal.dialog;
 
+import dn.data.LocaleString;
+
 class Retry extends ui.modal.Dialog {
-	public function new(str:dn.data.GetText.LocaleString, cb:Void->Void) {
+	public function new(str:LocaleString, cb:Void->Void) {
 		super("retry");
 
 		jContent.append('<h2>Error</h2>');

--- a/src/electron.renderer/ui/modal/dialog/Warning.hx
+++ b/src/electron.renderer/ui/modal/dialog/Warning.hx
@@ -1,7 +1,9 @@
 package ui.modal.dialog;
 
+import dn.data.LocaleString;
+
 class Warning extends ui.modal.Dialog {
-	public function new(str:dn.data.GetText.LocaleString) {
+	public function new(str:LocaleString) {
 		super("warning");
 
 		jContent.append('<h2>Warning</h2>');


### PR DESCRIPTION
Fixed LocaleString import paths to match the updated deepnightLibs library structure. LocaleString was moved from dn.data.GetText.LocaleString to dn.data.LocaleString in the latest version of deepnightLibs. This PR updates all references throughout the codebase and adds the necessary imports to files that use LocaleString.