### PR TITLE
FIX restoring window on macos after hiding

### DIFF
--- a/src/electron.main/ElectronMain.hx
+++ b/src/electron.main/ElectronMain.hx
@@ -26,6 +26,10 @@ class ElectronMain {
 			if( electron.main.BrowserWindow.getAllWindows().length == 0 )
 				showSplashWindow();
 		});
+		App.on('did-become-active', function() {
+			mainWindow.show();
+			mainWindow.maximize();
+		});
 
 		initIpcBindings();
 	}


### PR DESCRIPTION
I don't have a lot of experience working in haxe or electron, but after a tiny bit of research this seems to fix the issue. On macOS if you hide LDtk then restore it, the main window failed to show up.