### PR TITLE
FIX for startup events race condition on mac

### DIFF
--- a/src/electron.main/ElectronMain.hx
+++ b/src/electron.main/ElectronMain.hx
@@ -27,8 +27,10 @@ class ElectronMain {
 				showSplashWindow();
 		});
 		App.on('did-become-active', function() {
-			mainWindow.show();
-			mainWindow.maximize();
+			if( mainWindow != null && !mainWindow.isDestroyed() ) {
+				mainWindow.show();
+				mainWindow.maximize();
+			}
 		});
 
 		initIpcBindings();


### PR DESCRIPTION
This is a fix for the previous... fix. Apologies for needing a couple commits, but the "did-become-active" event can fire before `mainWindow` is valid on first launch, so this adds safety checks.