### PR TITLE
Add optional macOS touchpad navigation

### DIFF
--- a/app/assets/tpl/editAppSettings.html
+++ b/app/assets/tpl/editAppSettings.html
@@ -112,6 +112,14 @@
 			</dt>
 
 			<dt>
+				<label for="enableMacOsTouchPad">Enable MacOS TouchPad</label>
+				<info>Use two-finger scrolling to pan the editor and pinch gestures to zoom.</info>
+			</dt>
+			<dd>
+				<input type="checkbox" id="enableMacOsTouchPad"/>
+			</dd>
+
+			<dt>
 				<label for="mouseWheelSpeed">Mouse wheel speed</label>
 				<info>This setting affects the zoom in/out speed when using the mouse wheel.</info>
 			</dt>
@@ -186,4 +194,3 @@
 	</div>
 
 </div>
-

--- a/src/electron.common/Settings.hx
+++ b/src/electron.common/Settings.hx
@@ -27,6 +27,7 @@ typedef AppSettings = {
 
 	var appUiScale : Float;
 	var editorUiScale : Float;
+	var enableMacOsTouchPad : Bool;
 	var mouseWheelSpeed : Float;
 	var autoWorldModeSwitch : AutoWorldModeSwitch;
 	var fieldsRender : FieldsRender;
@@ -112,6 +113,7 @@ class Settings {
 			nearbyTilesRenderingDist: 1,
 			appUiScale: 1.0,
 			editorUiScale: 1.0,
+			enableMacOsTouchPad: false,
 			mouseWheelSpeed: 1.0,
 
 			uiStates: [],

--- a/src/electron.renderer/App.hx
+++ b/src/electron.renderer/App.hx
@@ -730,7 +730,7 @@ class App extends dn.Process {
 
 	function onAppMouseWheel(e:js.html.WheelEvent) {
 		if( hasPage() && !curPageProcess.isPaused() ) {
-			var spd = e.ctrlKey ? 0.20 : 0.01;
+			var spd = e.ctrlKey ? ( settings.v.enableMacOsTouchPad ? 0.10 : 0.20 ) : 0.01;
 			var delta = spd * -e.deltaY;
 			curPageProcess.onAppMouseWheel(delta, e.deltaX, e.deltaY, e.ctrlKey);
 		}

--- a/src/electron.renderer/App.hx
+++ b/src/electron.renderer/App.hx
@@ -732,7 +732,7 @@ class App extends dn.Process {
 		if( hasPage() && !curPageProcess.isPaused() ) {
 			var spd = e.ctrlKey ? 0.20 : 0.01;
 			var delta = spd * -e.deltaY;
-			curPageProcess.onAppMouseWheel(delta);
+			curPageProcess.onAppMouseWheel(delta, e.deltaX, e.deltaY, e.ctrlKey);
 		}
 	}
 

--- a/src/electron.renderer/Page.hx
+++ b/src/electron.renderer/Page.hx
@@ -17,7 +17,7 @@ class Page extends dn.Process {
 	public function onAppBlur() {}
 	public function onAppMouseDown() {}
 	public function onAppMouseUp() {}
-	public function onAppMouseWheel(delta:Float) {}
+	public function onAppMouseWheel(delta:Float, deltaX:Float, deltaY:Float, ctrlKey:Bool) {}
 	public function onAppFocus() {}
 	public function onAppResize() {}
 	public function onKeyDown(keyCode:Int) {}

--- a/src/electron.renderer/page/Editor.hx
+++ b/src/electron.renderer/page/Editor.hx
@@ -1298,14 +1298,27 @@ class Editor extends Page {
 	}
 
 	public var lastMouseWheelDelta = 0.;
-	override function onAppMouseWheel(delta:Float) {
-		super.onAppMouseWheel(delta);
+	var lastMouseWheelDeltaX = 0.;
+	var lastMouseWheelDeltaY = 0.;
+	var lastMouseWheelCtrlKey = false;
+	override function onAppMouseWheel(delta:Float, deltaX:Float, deltaY:Float, ctrlKey:Bool) {
+		super.onAppMouseWheel(delta, deltaX, deltaY, ctrlKey);
 		lastMouseWheelDelta = delta;
+		lastMouseWheelDeltaX = deltaX;
+		lastMouseWheelDeltaY = deltaY;
+		lastMouseWheelCtrlKey = ctrlKey;
 	}
 
 
 	function onHeapsMouseWheel(e:hxd.Event) {
-		deltaZoom( lastMouseWheelDelta*settings.v.mouseWheelSpeed, getMouse() );
+		if( settings.v.enableMacOsTouchPad && !lastMouseWheelCtrlKey ) {
+			camera.levelX += lastMouseWheelDeltaX / camera.adjustedZoom;
+			camera.levelY += lastMouseWheelDeltaY / camera.adjustedZoom;
+			camera.cancelAutoScrolling();
+			App.ME.requestCpu();
+		}
+		else
+			deltaZoom( lastMouseWheelDelta*settings.v.mouseWheelSpeed, getMouse() );
 		cursor.onMouseMove( getMouse() );
 	}
 

--- a/src/electron.renderer/ui/Tileset.hx
+++ b/src/electron.renderer/ui/Tileset.hx
@@ -684,16 +684,25 @@ class Tileset {
 
 
 	function onPickerMouseWheel(ev:js.html.WheelEvent) {
+		var touchpadNavigation = App.ME.settings.v.enableMacOsTouchPad;
+		if( ev.deltaY==0 && (!touchpadNavigation || ev.deltaX==0) )
+			return;
 
-		if( ev.deltaY!=0 ) {
-			ev.preventDefault();
-			if( viewFitted )
-				return;
+		ev.preventDefault();
+		if( viewFitted )
+			return;
 
+		if( touchpadNavigation && !ev.ctrlKey ) {
+			scrollX += ev.deltaX / zoom;
+			scrollY += ev.deltaY / zoom;
+			tx = ty = null;
+		}
+		else if( ev.deltaY!=0 ) {
 			var oldLocalX = pageToLocalX(ev.pageX);
 			var oldLocalY = pageToLocalY(ev.pageY);
 
-			zoom += -ev.deltaY*0.001 * zoom;
+			var zoomSpeed = touchpadNavigation && ev.ctrlKey ? 0.015 * App.ME.settings.v.mouseWheelSpeed : 0.001;
+			zoom += -ev.deltaY * zoomSpeed * zoom;
 
 			var newLocalX = pageToLocalX(ev.pageX);
 			var newLocalY = pageToLocalY(ev.pageY);

--- a/src/electron.renderer/ui/modal/dialog/EditAppSettings.hx
+++ b/src/electron.renderer/ui/modal/dialog/EditAppSettings.hx
@@ -186,6 +186,10 @@ class EditAppSettings extends ui.modal.Dialog {
 			onSettingChanged();
 		});
 
+		// macOS touchpad navigation
+		var i = Input.linkToHtmlInput(settings.v.enableMacOsTouchPad, jForm.find("#enableMacOsTouchPad"));
+		i.onChange = ()->onSettingChanged();
+
 		// Mouse wheel speed
 		var i = Input.linkToHtmlInput(settings.v.mouseWheelSpeed, jForm.find("#mouseWheelSpeed"));
 		i.setBounds(0.25, 3);


### PR DESCRIPTION
## Summary

- add an opt-in **Enable MacOS TouchPad** setting under Controls
- use two-finger movement to pan the editor camera when the setting is enabled
- tweak pinch-to-zoom function to feel good and behave consistently in main view and sidebar Tiles view. 
- keep the existing mouse-wheel zoom behavior as the default

## Motivation

On macOS TouchPads, LDtk currently treats two-finger vertical movement as zoom input, and ignores horizontal movement. This makes navigation different to common canvas tools, where two-finger movement pans the view, and pinch gestures zoom.

## The changes

This implementation reuses LDtk's existing camera movement and zoom paths. 

- added a settings menu checkbox for this function - so it's opt-in to keep existing mouse controls unchanged.

- working in both the main world view, and the sidebar "Tiles" view, and "Project Tilesets" view.

- when Touchpad mode is enabled, the existing "Mouse wheel speed" setting controls pinch-to-zoom sensitivity in both the main editor and tileset previews.

- when Touchpad mode is enabled, to keep a consistent feeling in both the world view, and sidebar views - this zoom sensitivity also applies to the sidebar views. 

This seemed to be the best way to handle this at the time, removing the need for another zoom sensitivity value. People who are regularly swapping between Mouse and Touchpad may not prefer this decision.

Related to #278, #480, #537, and #959.

## Testing

- launched the compiled Electron development build successfully on macOS and Windows 11 24H2

- verified on a physical macOS trackpad: two-finger panning and pinch-to-zoom work as expected

- verified with Apple Magic Mouse, usable as expected.

- verified with a Logitech G305 on macOS and Windows. Existing pointer and drag controls remain functional; with Touchpad mode enabled, wheel input pans rather than zooms by design.

Implementing this change over top of existing functionality and then removing the toggle checkbox could be an option, however some people who are used to the current trackpad control scheme and people trying windows and linux track-pads may encounter unpredictable results.

- unable to test on windows or linux trackpad, expect results will vary depending on driver and trackpad function support. Due to this, labeled as "macOS" as this functionality is expected on a macbook.

<img width="981" height="632" alt="SCR-20260722-olbe-2" src="https://github.com/user-attachments/assets/f96acc76-1e0b-4bde-a496-facc0c222c2a" />

AI disclosure: Developed with assistance from OpenAI Codex. The implementation was reviewed, compiled, and manually tested on physical hardware.
