### PR TITLE
consider nearby levels when evaluating auto-rules

### DIFF
--- a/src/electron.renderer/Tool.hx
+++ b/src/electron.renderer/Tool.hx
@@ -260,7 +260,7 @@ class Tool<T> extends dn.Process {
 
 
 	var needHistorySaving = false;
-	final function onEditAnything() {
+	function onEditAnything() {
 		editor.ge.emit( LayerInstanceEditedByTool(curLayerInstance) );
 		needHistorySaving = true;
 	}

--- a/src/electron.renderer/data/Level.hx
+++ b/src/electron.renderer/data/Level.hx
@@ -504,6 +504,10 @@ class Level {
 			&& wy>=worldY-padding && wy<worldY+pxHei+padding;
 	}
 
+	public inline function worldBoundsOverlaps(x, y, width, height) {
+		return dn.Lib.rectangleOverlaps(worldX, worldY, pxWid, pxHei, x, y, width, height);
+	}
+
 	public function getDist(wx:Int, wy:Int) : Float {
 		if( isWorldOver(wx,wy) )
 			return 0;

--- a/src/electron.renderer/data/World.hx
+++ b/src/electron.renderer/data/World.hx
@@ -284,13 +284,22 @@ class World {
 		return _project.getLevelAnywhere(uid);
 	}
 
-	public function getLevelAt(worldX:Int, worldY:Int) : Null<Level> {
+	public function getLevelAt(worldX:Int, worldY:Int, worldDepth: Int) : Null<Level> {
 		for(l in levels)
-			if( l.isWorldOver(worldX, worldY) )
+			if( l.worldDepth == worldDepth && l.isWorldOver(worldX, worldY) )
 				return l;
 		return null;
 	}
 
+	public function getLevelsOverlapping(worldX: Int, worldY: Int, width: Int, height: Int, worldDepth: Int) : Array<Level> {
+		var foundLevels = [];
+		for(level in levels) {
+			if(level.worldDepth == worldDepth && level.worldBoundsOverlaps(worldX, worldY, width, height))
+				foundLevels.push(level);
+		}
+
+		return foundLevels;
+	}
 
 	public function getShortName(maxLen=6) {
 		if( identifier.length<=maxLen )

--- a/src/electron.renderer/data/def/AutoLayerRuleDef.hx
+++ b/src/electron.renderer/data/def/AutoLayerRuleDef.hx
@@ -323,16 +323,40 @@ class AutoLayerRuleDef {
 
 	public function isRelevantInLayerAt(sourceLi:data.inst.LayerInstance, cx:Int, cy:Int) {
 		for(v in explicitlyRequiredValues) {
-			if( !sourceLi.containsIntGridValueOrGroup(v) )
+			if( size == 1 && !sourceLi.hasIntGridValueInArea(v,cx,cy) )
 				return false;
-			else if( size==1 && !sourceLi.hasIntGridValueInArea(v,cx,cy) )
-				return false;
-			else if( size>1
-				&& !sourceLi.hasIntGridValueInArea(v,cx-radius,cy-radius)
-				&& !sourceLi.hasIntGridValueInArea(v,cx+radius,cy-radius)
-				&& !sourceLi.hasIntGridValueInArea(v,cx+radius,cy+radius)
-				&& !sourceLi.hasIntGridValueInArea(v,cx-radius,cy+radius) )
+			else if( size > 1) {
+				var worldLeft = sourceLi.level.worldX + (cx - radius) * sourceLi.def.gridSize;
+				var worldRight = sourceLi.level.worldX + (cx + radius) * sourceLi.def.gridSize;
+				var worldTop = sourceLi.level.worldY + (cy - radius) * sourceLi.def.gridSize;
+				var worldBottom = sourceLi.level.worldY + (cy + radius) * sourceLi.def.gridSize;
+				var nearbyLevels = Editor.ME.curWorld.getLevelsOverlapping(worldLeft, worldTop, worldRight-worldLeft, worldBottom-worldTop, sourceLi.level.worldDepth);
+
+				var foundValue = false;
+				for(nLevel in nearbyLevels) {
+					var nLi = nLevel.getLayerInstance(sourceLi.def.uid);
+					var levelLeft = dn.M.imax( nLi.level.worldX, worldLeft) - nLi.level.worldX;
+					var levelRight = dn.M.imin( nLi.level.worldX + nLi.level.pxWid - nLi.def.gridSize, worldRight) - nLi.level.worldX;
+					var levelTop = dn.M.imax( nLi.level.worldY, worldTop ) - nLi.level.worldY;
+					var levelBottom = dn.M.imin( nLi.level.worldY + nLi.level.pxHei - nLi.def.gridSize, worldBottom) - nLi.level.worldY;
+
+					var cLeft = Std.int(levelLeft / nLi.def.gridSize);
+					var cRight = Std.int(levelRight / nLi.def.gridSize);
+					var cTop = Std.int(levelTop / nLi.def.gridSize);
+					var cBottom = Std.int(levelBottom / nLi.def.gridSize);
+
+					if( nLi.hasIntGridValueInArea(v,cLeft,cTop)
+						|| nLi.hasIntGridValueInArea(v,cRight,cTop)
+						|| nLi.hasIntGridValueInArea(v,cRight,cBottom)
+						|| nLi.hasIntGridValueInArea(v,cLeft,cBottom) ) {
+						foundValue = true;
+						break;
+					}
+				}
+				if(!foundValue) {
 					return false;
+				}
+			}
 		}
 		return true;
 	}
@@ -357,8 +381,27 @@ class AutoLayerRuleDef {
 			if( pattern[coordId]==0 )
 				continue;
 
-			value = source.isValid( cx+dirX*(px-radius), cy+dirY*(py-radius) )
-				? source.getIntGrid( cx+dirX*(px-radius), cy+dirY*(py-radius) )
+			var cpx = cx+dirX*(px-radius);
+			var cpy = cy+dirY*(py-radius);
+			var nSource = source;
+			if (!source.isValid(cpx, cpy)) {
+				// This point is in a nearby level, look it up by world position and transform the point to be local to it.
+				var worldX = source.level.worldX + cpx * source.def.gridSize;
+				var worldY = source.level.worldY + cpy * source.def.gridSize;
+				var neighborLevel = Editor.ME.curWorld.getLevelAt(worldX,worldY,source.level.worldDepth);
+				if(neighborLevel != null)
+				{
+					var neighborLayer = neighborLevel.getLayerInstance(source.layerDefUid);
+					var nx = Std.int((worldX - neighborLevel.worldX) / neighborLayer.def.gridSize);
+					var ny = Std.int((worldY - neighborLevel.worldY) / neighborLayer.def.gridSize);
+
+					nSource = neighborLayer;
+					cpx = nx;
+					cpy = ny;
+				}
+			}
+			value = nSource.isValid(cpx, cpy)
+				? nSource.getIntGrid(cpx, cpy)
 				: outOfBoundsValue;
 
 			if( value==null )
@@ -374,7 +417,7 @@ class AutoLayerRuleDef {
 			}
 			else if( dn.M.iabs( pattern[coordId] ) > 999 ) {
 				// Group checks
-				valueInf = source.def.getIntGridValueDef(value);
+				valueInf = nSource.def.getIntGridValueDef(value);
 				if( pattern[coordId]>0 && ( valueInf==null || valueInf.groupUid != Std.int(pattern[coordId]/1000)-1 ) )
 					return false;
 

--- a/src/electron.renderer/data/inst/LayerInstance.hx
+++ b/src/electron.renderer/data/inst/LayerInstance.hx
@@ -1077,39 +1077,54 @@ class LayerInstance {
 
 	/** Apply all rules to specific cell **/
 	public function applyAllRulesAt(cx:Int, cy:Int, wid:Int, hei:Int) {
-		if( !def.autoLayerRulesCanBeUsed() ) {
-			clearAllAutoTilesCache();
-			return;
-		}
-
-		var source = def.type==IntGrid ? this : def.autoSourceLayerDefUid!=null ? level.getLayerInstance(def.autoSourceLayerDefUid) : null;
-		if( source==null ) {
-			clearAllAutoTilesCache();
-			return;
-		}
-
-		if( autoTilesCache==null ) {
-			applyAllRules();
-			return;
-		}
-
 		// Adjust bounds to also redraw nearby cells
 		var maxRadius = Std.int( Const.MAX_AUTO_PATTERN_SIZE*0.5 );
-		var left = dn.M.imax( 0, cx - maxRadius );
-		var right = dn.M.imin( cWid-1, cx + wid-1 + maxRadius );
-		var top = dn.M.imax( 0, cy - maxRadius );
-		var bottom = dn.M.imin( cHei-1, cy + hei-1 + maxRadius );
+		var worldLeft = level.worldX + (cx - maxRadius) * def.gridSize;
+		var worldRight = level.worldX + (cx + wid + maxRadius) * def.gridSize;
+		var worldTop = level.worldY + (cy - maxRadius) * def.gridSize;
+		var worldBottom = level.worldY + (cy + hei + maxRadius) * def.gridSize;
+		var nearbyLevels = Editor.ME.curWorld.getLevelsOverlapping(worldLeft, worldTop, worldRight-worldLeft, worldBottom-worldTop, level.worldDepth);
 
-		// Apply rules
-		def.iterateActiveRulesInEvalOrder( this, (r)->{
-			clearAutoTilesCacheRect(r, left,top, right-left+1, bottom-top+1);
-			for(x in left...right+1)
-			for(y in top...bottom+1)
-				applyRuleAt(source, r, x,y);
-		});
+		for (nLevel in nearbyLevels) {
+			var li = nLevel.getLayerInstance(layerDefUid);
+			if( !li.def.autoLayerRulesCanBeUsed() ) {
+				li.clearAllAutoTilesCache();
+				continue;
+			}
 
-		// Discard using break-on-match flag
-		applyBreakOnMatchesArea(left,top, right-left+1, bottom-top+1);
+			var source = li.def.type==IntGrid ? li : li.def.autoSourceLayerDefUid!=null ? nLevel.getLayerInstance(li.def.autoSourceLayerDefUid) : null;
+			if( source==null ) {
+				li.clearAllAutoTilesCache();
+				continue;
+			}
+
+			if( li.autoTilesCache==null ) {
+				li.applyAllRules();
+				continue;
+			}
+
+			var levelLeft = dn.M.imax( nLevel.worldX, worldLeft) - nLevel.worldX;
+			var levelRight = dn.M.imin( nLevel.worldX + nLevel.pxWid - li.def.gridSize, worldRight) - nLevel.worldX;
+			var levelTop = dn.M.imax( nLevel.worldY, worldTop ) - nLevel.worldY;
+			var levelBottom = dn.M.imin( nLevel.worldY + nLevel.pxHei - li.def.gridSize, worldBottom) - nLevel.worldY;
+
+			var cLeft = Std.int(levelLeft / li.def.gridSize);
+			var cRight = Std.int(levelRight / li.def.gridSize);
+			var cTop = Std.int(levelTop / li.def.gridSize);
+			var cBottom = Std.int(levelBottom / li.def.gridSize);
+
+			// Apply rules
+			li.def.iterateActiveRulesInEvalOrder( this, (r)->{
+				li.clearAutoTilesCacheRect(r, cLeft, cTop, cRight-cLeft+1, cBottom-cTop+1);
+				for(x in cLeft...cRight+1)
+				for(y in cTop...cBottom+1)
+					li.applyRuleAt(source, r, x,y);
+			});
+
+			// Discard using break-on-match flag
+			li.applyBreakOnMatchesArea(cLeft,cTop, cRight-cLeft+1, cBottom-cTop+1);
+
+		}
 	}
 
 	/** Apply all rules to all cells **/

--- a/src/electron.renderer/page/Editor.hx
+++ b/src/electron.renderer/page/Editor.hx
@@ -722,12 +722,32 @@ class Editor extends Page {
 				);
 
 			case C_Undo:
-				if( !worldMode && !hasInputFocus() && !ui.Modal.hasAnyOpen() )
+				if( !worldMode && !hasInputFocus() && !ui.Modal.hasAnyOpen() ) {
 					curLevelTimeline.undo();
 
+					var neig = curLevel.getNeighboursIids();
+					for(iid in neig) {
+						var nLevel = project.getLevelAnywhere(iid);
+						invalidateLevelCache( nLevel );
+						for(li in nLevel.layerInstances) {
+							li.applyAllRules();
+						}
+					}
+				}
+
 			case C_Redo:
-				if( !worldMode && !hasInputFocus() && !ui.Modal.hasAnyOpen() )
+				if( !worldMode && !hasInputFocus() && !ui.Modal.hasAnyOpen() ) {
 					curLevelTimeline.redo();
+
+					var neig = curLevel.getNeighboursIids();
+					for(iid in neig) {
+						var nLevel = project.getLevelAnywhere(iid);
+						invalidateLevelCache( nLevel );
+						for(li in nLevel.layerInstances) {
+							li.applyAllRules();
+						}
+					}
+				}
 
 			case C_AppSettings:
 				if( !ui.Modal.isOpen(ui.modal.dialog.EditAppSettings) ) {
@@ -2112,16 +2132,29 @@ class Editor extends Page {
 					var newNeig = level.getNeighboursIids();
 
 					// Invalidate old neighbours
-					for(iid in oldNeig)
-						invalidateLevelCache( project.getLevelAnywhere(iid) );
+					for(iid in oldNeig) {
+						var nLevel = project.getLevelAnywhere(iid);
+						invalidateLevelCache( nLevel );
+						for(li in nLevel.layerInstances) {
+							li.applyAllRules();
+						}
+					}
 
 					// Invalidate new neighbours
-					for(iid in newNeig)
-						invalidateLevelCache( project.getLevelAnywhere(iid) );
+					for(iid in newNeig) {
+						var nLevel = project.getLevelAnywhere(iid);
+						invalidateLevelCache( nLevel );
+						for(li in nLevel.layerInstances) {
+							li.applyAllRules();
+						}
+					}
 
 					switch curWorld.worldLayout {
 						case Free, GridVania: invalidateLevelCache(level);
 						case LinearHorizontal, LinearVertical: invalidateLevelCache(level);
+					}
+					for(li in level.layerInstances) {
+						li.applyAllRules();
 					}
 				}
 

--- a/src/electron.renderer/tool/lt/IntGridTool.hx
+++ b/src/electron.renderer/tool/lt/IntGridTool.hx
@@ -34,6 +34,16 @@ class IntGridTool extends tool.LayerTool<Int> {
 		editor.selectionTool.clear();
 	}
 
+	override function onEditAnything() {
+		super.onEditAnything();
+
+		// Auto-tiles in nearby levels may have updated so we need to mark them as dirty and redraw the nearby level preview
+		for( l in curLevel.getNeighbours()) {
+			editor.invalidateLevelCache(l);
+			editor.worldRender.invalidateLevelRender(l);
+		}
+	}
+
 	override function customCursor(ev:hxd.Event, m:Coords) {
 		super.customCursor(ev,m);
 

--- a/src/electron.renderer/ui/vp/LevelSpotPicker.hx
+++ b/src/electron.renderer/ui/vp/LevelSpotPicker.hx
@@ -128,12 +128,6 @@ class LevelSpotPicker extends ui.ValuePicker<Coords> {
 		return dh.getBest();
 	}
 
-
-	static inline function boundsOverlaps(l:data.Level, x,y,w,h) {
-		return dn.Lib.rectangleOverlaps( x, y, w, h, l.worldX, l.worldY, l.pxWid, l.pxHei );
-	}
-
-
 	/**
 		Return a valid level insertion spot near Coords, or null if none.
 	**/
@@ -152,13 +146,12 @@ class LevelSpotPicker extends ui.ValuePicker<Coords> {
 		// Find a spot in world space
 		switch world.worldLayout {
 			case Free, GridVania:
-
-				if( world.getLevelAt(m.worldX, m.worldY)!=null )
+				if( world.getLevelAt(m.worldX, m.worldY, Editor.ME.curWorldDepth)!=null )
 					b.overlaps = true;
 				else {
 					// Deinterlace with existing levels
 					for(l in world.levels)
-						if( boundsOverlaps( l, b.x, b.y, b.wid, b.hei ) ) {
+						if( l.worldBoundsOverlaps(b.x, b.y, b.wid, b.hei) ) {
 							// Source: https://stackoverflow.com/questions/1585525/how-to-find-the-intersection-point-between-a-line-and-a-rectangle
 							var slope = ( (b.y+b.hei*0.5)-l.worldCenterY )  /  ( (b.x+b.wid*0.5)-l.worldCenterX );
 							if( slope*l.pxWid*0.5 >= -l.pxHei*0.5  &&  slope*l.pxWid*0.5 <= l.pxHei*0.5 )
@@ -176,7 +169,7 @@ class LevelSpotPicker extends ui.ValuePicker<Coords> {
 
 					// Deinterlace failed
 					for(l in world.levels)
-						if( boundsOverlaps(l, b.x, b.y, b.wid, b.hei) ) {
+						if( l.worldBoundsOverlaps(b.x, b.y, b.wid, b.hei) ) {
 							b.overlaps = true;
 							break;
 						}


### PR DESCRIPTION
Closes #716 

This is a first pass on this feature. I tried to implement it as minimally invasive as possible, but as far as I can tell levels interacting with each other is a pretty new concept to ldtk so I wouldn't be surprised if you have a lot of feedback.

Note: I am using a "dual-grid" tileset system in this example. That is why the int grid is offset from the level bounds.
Gif:
<img width="1226" height="594" alt="Recording 2026-08-16 183952" src="https://github.com/user-attachments/assets/e3e4a717-2565-46a3-b39a-2fd455c56cd5" />


Considerations:
- Undo/Redo: Changes to neighboring levels are not saved to any timeline, but neighboring level's auto-rules are revaluated whenever a level undo/redo event occurs. This seems "fine" since no actual tile placement will change in a neighboring level, just their auto-tile cache, but I might be missing something.
- Neighboring levels are invalidated to ensure that they will be marked as dirty and have any updated auto-tiles saved when the project is saved.
- Auto-tile rules are reevaluated when a level is moved

Now I'll be trying to actually use this patch for a while in my own project and see if I find anything missing :)